### PR TITLE
categoriesテーブルのanecetryカラムのoption削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,4 @@ group :production do
 end
 
 gem 'haml-rails'
+gem 'ancestry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
+    ancestry (3.0.7)
+      activerecord (>= 3.2.0)
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
@@ -248,6 +250,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ancestry
   bootsnap (>= 1.1.0)
   byebug
   capistrano

--- a/db/migrate/20200717221850_create_categories.rb
+++ b/db/migrate/20200717221850_create_categories.rb
@@ -2,7 +2,7 @@ class CreateCategories < ActiveRecord::Migration[5.2]
   def change
     create_table :categories do |t|
       t.string :category, null: false
-      t.string :anecetry
+      t.string :ancestry
       t.timestamps
     end
   end

--- a/db/migrate/20200717221850_create_categories.rb
+++ b/db/migrate/20200717221850_create_categories.rb
@@ -1,8 +1,8 @@
 class CreateCategories < ActiveRecord::Migration[5.2]
   def change
     create_table :categories do |t|
-      t.string :category,null: false
-      t.string :anecetry,null: false
+      t.string :category, null: false
+      t.string :anecetry
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,7 @@ ActiveRecord::Schema.define(version: 2020_07_17_221850) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "category", null: false
-    t.string "anecetry"
+    t.string "ancestry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,7 @@ ActiveRecord::Schema.define(version: 2020_07_17_221850) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "category", null: false
-    t.string "anecetry", null: false
+    t.string "anecetry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
#What
categoriesテーブルのanecetryカラムのoptionであるnull: falseの記述を削除

#Why
anecetryカラムは、親要素がnilになるため、optionでnull :falseを入れてしまうとエラーが出る為