### PR TITLE
creditcardsテーブルの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,9 @@
 ## creditcardsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|card_number|bigint|null: false, foreign_key: true|
-|year|integer|null: false|
-|month|integer|null: false|
-|sequrity_code|integer|null: false|
 |user_id|references|null: false, foreign_key: true|
+|costomer_id|integer|null: false|
+|card_id|integer|null: false|
 
 ### Association
 - belongs_to user


### PR DESCRIPTION
# What
creditcardsテーブルのカラムを変更。

# Why
カード情報は、DBに保存せず、payjpにて保存をするため、トークンという形で保存できるように実装した。

costomer_id,card_idは、カード番号(16桁),有効期限年月,セキュリティーコードを渡すとpay.jpから返ってくるデータ。