### PR TITLE
新規登録に必要なテーブルにバリデーションをかける

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 |prefecture|integer|null: false|
 |city|string|null: false|
 |house_number|string|null: false|
-|building|string|null: false|
+|building|string||
 |home_call_num|integer||
 |user_id|references|null: false, foreign_key: true|
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 |email|string|null: false, unique: true|
 |encrypted_password|string|null: false|
 |family_name|string|null: false|
-|first_name|string|null: false, unique: true|
+|first_name|string|null: false|
 |family_name_kana|string|null: false|
 |first_name_kana|string|null: false|
 |birth_year|integer|null: false|

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 |city|string|null: false|
 |house_number|string|null: false|
 |building|string|null: false|
-|phone_number|integer|null: false|
+|home_call_num|integer||
 |user_id|references|null: false, foreign_key: true|
 
 ### Association

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
 
@@ -12,5 +13,11 @@ class ApplicationController < ActionController::Base
       username == Rails.application.credentials[:basic_auth][:user] &&
       password == Rails.application.credentials[:basic_auth][:pass]
     end
+  end
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_year, :birth_month, :birth_day, :phone_number])
   end
 end

--- a/app/models/shipping_info.rb
+++ b/app/models/shipping_info.rb
@@ -1,0 +1,2 @@
+class ShippingInfo < ApplicationRecord
+end

--- a/app/models/shipping_info.rb
+++ b/app/models/shipping_info.rb
@@ -1,2 +1,7 @@
 class ShippingInfo < ApplicationRecord
+  belongs_to :user
+
+  validates :family_name, :first_name, :postcode, :prefecture, :city, :house_number, :user_id, presence: true
+  # ↓正規表現でカタカナだけのバリデーションをかける(複雑そうなので後回し)
+  validates :family_name_kana, :first_name_kana, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   
   validates :nickname, presence: true, length: {maximum: 20}
   # ↓正規表現で@とドメインを必須にする(複雑そうなので後回し)
-  validates :email, presence: true, uniquness:true
+  validates :email, presence: true
   validates :password, presence: true, length: {minimum: 7}
   validates :password_confirmation, presence: true, length: {minimum: 7}
   # ↓正規表現で全角のバリデーションをかける(複雑そうなので後回し)
@@ -15,9 +15,8 @@ class User < ApplicationRecord
   validates :family_name_kana, :first_name_kana, presence: true
   validates :birth_year, :birth_month, :birth_day, presence: true
 
-  
 
-  # has_one :shipping_info, dependent: :destroy
+  has_one :shipping_info, dependent: :destroy
   # has_many :todo_lists, ependent: :destroy
   # has_one :creditcard, dependent: :destroy
   # has_many :comments, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,26 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  
+  validates :nickname, presence: true, length: {maximum: 20}
+  # ↓正規表現で@とドメインを必須にする(複雑そうなので後回し)
+  validates :email, presence: true, uniquness:true
+  validates :password, presence: true, length: {minimum: 7}
+  validates :password_confirmation, presence: true, length: {minimum: 7}
+  # ↓正規表現で全角のバリデーションをかける(複雑そうなので後回し)
+  validates :family_name, :first_name, presence: true
+  # ↓正規表現でカタカナだけのバリデーションをかける(複雑そうなので後回し)
+  validates :family_name_kana, :first_name_kana, presence: true
+  validates :birth_year, :birth_month, :birth_day, presence: true
+
+  
+
+  # has_one :shipping_info, dependent: :destroy
+  # has_many :todo_lists, ependent: :destroy
+  # has_one :creditcard, dependent: :destroy
+  # has_many :comments, dependent: :destroy
+  # has_many :favorites, dependent: :destroy
+  # has_many :evaluations, dependent: :destroy
+  # has_many :seller_items, foreign_key: “seller_id”, class_name: “items”
+  # has_many :buyer_items, foreign_key: “buyer_id”, class_name: “items”
 end

--- a/db/migrate/20200725122028_devise_create_users.rb
+++ b/db/migrate/20200725122028_devise_create_users.rb
@@ -3,8 +3,18 @@
 class DeviseCreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
+      t.string :nickname,         null: false
+      t.string :family_name,      null: false
+      t.string  :first_name,      null: false
+      t.string :family_name_kana, null: false
+      t.string :first_name_kana,  null: false
+      t.integer :birth_year,      null: false
+      t.integer :birth_month,     null: false
+      t.integer :birth_day,       null: false
+      t.text :introduction
+      t.string :icon
+      
       ## Database authenticatable
-      t.string :nickname,           null: false
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
 
@@ -34,8 +44,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
-
-
       t.timestamps null: false
     end
 

--- a/db/migrate/20200729064926_create_shipping_infos.rb
+++ b/db/migrate/20200729064926_create_shipping_infos.rb
@@ -9,9 +9,9 @@ class CreateShippingInfos < ActiveRecord::Migration[5.2]
       t.integer :prefecture,      null: false
       t.string :city,             null: false
       t.string :house_number,     null: false
-      t.string :building,         null: false
-      t.integer :home_call_num, 
-      t.references :user_id,      null: false, foreign_key: true
+      t.string :building
+      t.integer :home_call_num
+      t.references :user,         null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20200729064926_create_shipping_infos.rb
+++ b/db/migrate/20200729064926_create_shipping_infos.rb
@@ -1,17 +1,17 @@
 class CreateShippingInfos < ActiveRecord::Migration[5.2]
   def change
     create_table :shipping_infos do |t|
-      t.string :family_name, null: false
-      t.string :first_name, null: false
+      t.string :family_name,      null: false
+      t.string :first_name,       null: false
       t.string :family_name_kana, null: false
-      t.string :first_name_kana, null: false
-      t.integer :postcode, null: false
-      t.integer :prefecture, null: false
-      t.string :city, null: false
-      t.string :house_number, null:false
-      t.string :building, null: false
-      t.integer :phone_number, 
-
+      t.string :first_name_kana,  null: false
+      t.integer :postcode,        null: false
+      t.integer :prefecture,      null: false
+      t.string :city,             null: false
+      t.string :house_number,     null: false
+      t.string :building,         null: false
+      t.integer :home_call_num, 
+      t.references :user_id,      null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20200729064926_create_shipping_infos.rb
+++ b/db/migrate/20200729064926_create_shipping_infos.rb
@@ -1,0 +1,18 @@
+class CreateShippingInfos < ActiveRecord::Migration[5.2]
+  def change
+    create_table :shipping_infos do |t|
+      t.string :family_name, null: false
+      t.string :first_name, null: false
+      t.string :family_name_kana, null: false
+      t.string :first_name_kana, null: false
+      t.integer :postcode, null: false
+      t.integer :prefecture, null: false
+      t.string :city, null: false
+      t.string :house_number, null:false
+      t.string :building, null: false
+      t.integer :phone_number, 
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_25_122028) do
+ActiveRecord::Schema.define(version: 2020_07_29_064926) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "ancestry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "shipping_infos", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "family_name", null: false
+    t.string "first_name", null: false
+    t.string "family_name_kana", null: false
+    t.string "first_name_kana", null: false
+    t.integer "postcode", null: false
+    t.integer "prefecture", null: false
+    t.string "city", null: false
+    t.string "house_number", null: false
+    t.string "building"
+    t.integer "home_call_num"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_shipping_infos_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -41,4 +58,5 @@ ActiveRecord::Schema.define(version: 2020_07_25_122028) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "shipping_infos", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2020_07_25_122028) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -21,6 +20,16 @@ ActiveRecord::Schema.define(version: 2020_07_25_122028) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "nickname", null: false
+    t.string "family_name", null: false
+    t.string "first_name", null: false
+    t.string "family_name_kana", null: false
+    t.string "first_name_kana", null: false
+    t.integer "birth_year", null: false
+    t.integer "birth_month", null: false
+    t.integer "birth_day", null: false
+    t.text "introduction"
+    t.string "icon"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"

--- a/test/fixtures/shipping_infos.yml
+++ b/test/fixtures/shipping_infos.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/shipping_info_test.rb
+++ b/test/models/shipping_info_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ShippingInfoTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
新規登録の際に保存するテーブル(usersテーブル、shipping_infosテーブル)を作成し、バリデーションを掛けた。
しかし進捗の関係で、マークアップのタスクを進めるため、正規表現を用いた実装は後回しにする。
なお、新規登録は、ウィザード形式で実装する。

# Why
新規登録、ログイン機能は必須機能なため。
ーーーーーーーー

shipping_infosテーブルのphone_numberにカラム関して、お届け先の電話番号は任意とのことだったので、phone_numberをhome_call_numに変更し、null:falseを外した
マンション名等も任意のため、null: falseを外した。
first_nameカラムに、なぜかunique: trueオプションが記述されていたため、削除した。

UsersモデルはREADMEに記載されているアソシエーション全てを記述した(今回の実装で必要のない箇所は現在コメントアウトしている)

password、password_confirmationカラムが存在しないのにモデルに記述がある理由として、password、password_confirmationが一致した時にencrypted_passwordカラムに暗号化され保存される仕様になっているそうなので、この様に実装した。
マークアップでエラーが出る様ならば見直す必要がある。
確認をお願い致します。
