### PR TITLE
READMEの変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@
 |Column|Type|Options|
 |------|----|-------|
 |user_id|references|null: false, foreign_key: true|
-|costomer_id|integer|null: false|
-|card_id|integer|null: false|
+|costomer_id|string|null: false|
+|card_id|string|null: false|
 
 ### Association
 - belongs_to user
@@ -148,7 +148,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |category|string|null: false|
-|anecetry|string|null: false|
+|anecetry|string||
 
 ### Association
 - has_many :items


### PR DESCRIPTION
# What
クレジットカードテーブルと、カテゴリーテーブルの変更をする。

クレジットカードテーブル→integerをstringに変更
カテゴリーテーブル→anecetryカラムのoptionのnull: falseを削除

# Why
前回のスプリントレビュー でご指摘があったのと、再度確認し、調べたところ、他チームと少し違っていたため。

参考記事
https://qiita.com/emincoring/items/ce29dbbd182aa3c49c6b