### PR TITLE
application.html.hamlの編集

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,8 @@
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag    '', media: 'all', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    %script{:src => "https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"}
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = yield


### PR DESCRIPTION
# What
assetディレクトリの内容が反映されない問題が発生。

# Why
ビューが乱れたため。

layoutディレクトリ直下のapplication.html.hamlに原因があった。