### PR TITLE
ユーザーマイページでクレジットカード画面を表示

### DIFF
--- a/app/views/creditcards/index.html.haml
+++ b/app/views/creditcards/index.html.haml
@@ -1,27 +1,30 @@
-= render "users/mypage_side"
-.creditcards-main
-  = render partial: "header_creditcards"
-  .creditcards-main__box
-    %section.header-title
-      %h1 支払い方法
-    .creditcards-main__box__content
-      %section.creditcard-section
-        %h2 クレジットカード
-      - if @card.present?
-        = form_with url: "/creditcards/new", method: :delete, local: true do |f|
-          .container
-            .container__info
-              = image_tag "#{@card_image}", width: "34", height: "20", alt: "creditcard"
-              %p 番号
-              = "**** **** " + @card_information.last4
-              %p 有効期限
-              - exp_month = @card_information.exp_month.to_s
-              - exp_year = @card_information.exp_year.to_s.slice(2, 3)
-              = exp_month + "/" + exp_year
-            .container__btn
-              %input{type: "hidden", name: "cards_id", value: ""}
-              = f.submit "削除する", class: "creditcard__delete--btn" 
-      - else
-        .create-card
-          = link_to "クレジットカードを追加する", new_creditcard_path, class: "create-card-btn"
-  = render partial: "footer_creditcards" 
+= render partial: "items/header"
+.container
+  = render "users/mypage_side"
+  
+  .creditcards-main
+    = render partial: "header_creditcards"
+    .creditcards-main__box
+      %section.header-title
+        %h1 支払い方法
+      .creditcards-main__box__content
+        %section.creditcard-section
+          %h2 クレジットカード
+        - if @card.present?
+          = form_with url: "/creditcards/new", method: :delete, local: true do |f|
+            .container
+              .container__info
+                = image_tag "#{@card_image}", width: "34", height: "20", alt: "creditcard"
+                %p 番号
+                = "**** **** " + @card_information.last4
+                %p 有効期限
+                - exp_month = @card_information.exp_month.to_s
+                - exp_year = @card_information.exp_year.to_s.slice(2, 3)
+                = exp_month + "/" + exp_year
+              .container__btn
+                %input{type: "hidden", name: "cards_id", value: ""}
+                = f.submit "削除する", class: "creditcard__delete--btn" 
+        - else
+          .create-card
+            = link_to "クレジットカードを追加する", new_creditcard_path, class: "create-card-btn"
+= render partial: "footer_creditcards" 


### PR DESCRIPTION
# WHAT
 ユーザーマイページにて、クレジットカード登録画面に遷移する際、仕様をマイページ同様にする

# WHY
ユーザビリティ向上のため