### PR TITLE
依頼後のユーザー新規登録の修正

### DIFF
--- a/app/models/shipping_info.rb
+++ b/app/models/shipping_info.rb
@@ -1,6 +1,6 @@
 class ShippingInfo < ApplicationRecord
   belongs_to :user, optional: true
 
-  validates :family_name, :first_name, :postcode, :prefecture, :city, :house_number, presence: true
-  validates :family_name_kana, :first_name_kana, presence: true, format: { with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/ }, allow_blank: true # カタカナのみ
+  validates :family_name, :first_name, :postcode, :prefecture, :city, :house_number, :family_name_kana, :first_name_kana, presence: true
+  validates :family_name_kana, :first_name_kana, format: { with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/ }, allow_blank: true # カタカナのみ
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   
   validates :nickname, presence: true, length: {maximum: 20}
-  # ↓正規表現で@とドメインを必須にする(複雑そうなので後回し)
   validates :email, presence: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
   validates :password, presence: true, length: {minimum: 7},format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{7,128}+\z/i, message: "は英字と数字両方を含むパスワードを設定してください" } # 英字と数字の両方を含む7文字以上128文字以下
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,8 @@ class User < ApplicationRecord
   validates :password, presence: true, length: {minimum: 7},format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{7,128}+\z/i, message: "は英字と数字両方を含むパスワードを設定してください" } # 英字と数字の両方を含む7文字以上128文字以下
 
   validates :family_name, :first_name, presence: true, length: { maximum: 35 }, format: { with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々]|[a-zA-Z]|[ｧ-ﾝﾞﾟ]|[ａ-ｚＡ-Ｚ])+\z/i } # 全角ひらがな、全角カタカナ、漢字、半角英字、半角カタカナ、全角英字
- 
-  validates :family_name_kana, :first_name_kana, presence: true, length: { maximum: 35 }, format: { with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/ } # カタカナのみ
+
+  validates :family_name_kana, :first_name_kana, length: { maximum: 35 }, format: { with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/ } # カタカナのみ
   validates :birth_year, :birth_month, :birth_day, presence: true
 
 

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -35,6 +35,18 @@ ja:
         birth_year: 生年
         birth_month: 生月
         birth_day: 生日
+      shipping_info:
+        family_name: 苗字
+        first_name: 名前
+        family_name_kana: 苗字(カナ)
+        family_name_kana: 名前(カナ)
+        first_name_kana: 苗字(カナ)
+        first_name: 名前(カナ)
+        postcode: 郵便番号
+        prefecture: 都道府県
+        city: 市町村
+        house_number: 番地
+
 
     models:
       user: ユーザ


### PR DESCRIPTION
# What
「新規登録時、必須項目である送付先氏名(ふりがな)が、空の状態でも登録が可能な状態」
を修正する。

#Why
必須項目のため。

エラー文が、usersテーブルのみで、shipping_infoの日本語化を失念していたため、追記しました