### PR TITLE
編集画面にて、親カテゴリーの取得

### DIFF
--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -11,7 +11,7 @@
           = f.label :"カテゴリー" 
           %span.sell-new__wrapper__form__field__attention 必須
           %br/
-          =f.collection_select :category_id, @item.category.root.siblings, :id, :name, class:"serect_field"
+          =f.collection_select :category_id, @item.category.root.siblings, :id, :name, {selected:@item.category.root.id}, class:"serect_field"
           #children_wrapper 
             =f.collection_select :category_id, @item.category.parent.siblings, :id, :name, class:"serect_field"
           #grandchildren_wrapper


### PR DESCRIPTION
# What
保存されなかった親カテゴリーを取得し、表示する

# Why
編集画面にて、親カテゴリーが保存されていなかったため。