### PR TITLE
新規登録後cssの自動生成を消す実装

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module C74Furima
     config.load_defaults 5.2
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', 'item.ja.yml').to_s]
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
# What
エラー時自動でcssが変わらない様記述。

# Why
ユーザビリテュの向上のため。